### PR TITLE
moved commands outside of the reducer

### DIFF
--- a/ui/src/alfresco/DockerContainerCreate.tsx
+++ b/ui/src/alfresco/DockerContainerCreate.tsx
@@ -25,7 +25,7 @@ import {
   AlfrescoStates,
   AlfrescoState,
 } from './alfrescoServices';
-
+import { runContainers, stopContainers } from '../helper/cli';
 const CommandPanel = ({ alfrescoState, dispatch }) => {
   return (
     <React.Fragment>
@@ -35,6 +35,7 @@ const CommandPanel = ({ alfrescoState, dispatch }) => {
           variant="contained"
           onClick={(e) => {
             e.preventDefault();
+            runContainers();
             dispatch({ type: 'START_ALFRESCO' });
           }}
           startIcon={<PlayIcon />}
@@ -50,6 +51,7 @@ const CommandPanel = ({ alfrescoState, dispatch }) => {
           variant="contained"
           onClick={(e) => {
             e.preventDefault();
+            stopContainers();
             dispatch({ type: 'STOP_ALFRESCO' });
           }}
           startIcon={<StopIcon />}

--- a/ui/src/alfresco/alfrescoServices.ts
+++ b/ui/src/alfresco/alfrescoServices.ts
@@ -5,14 +5,6 @@ import {
   readySolr,
   readyTransform,
   alfrescoContainers,
-  createNetwork,
-  deployDb,
-  deployMq,
-  deployTransform,
-  deploySolr,
-  waitTillReadyDb,
-  deployRepository,
-  stopContainers,
 } from '../helper/cli';
 
 import {
@@ -82,17 +74,6 @@ export function defaultAlfrescoState(): ServiceStore {
     errors: [],
   };
 }
-
-const runContainers = async () => {
-  await createNetwork();
-  await deployDb();
-  await deployMq();
-  await deployTransform();
-  await deploySolr();
-
-  await waitTillReadyDb();
-  await deployRepository();
-};
 
 function updateStateWith(
   data: ServiceDescriptor[],
@@ -164,12 +145,11 @@ export function serviceReducer(
     }
     case 'START_ALFRESCO': {
       newState.alfrescoState = AlfrescoStates.STARTING;
-      runContainers();
       return newState;
     }
     case 'STOP_ALFRESCO': {
       newState.alfrescoState = AlfrescoStates.STOPPING;
-      stopContainers();
+
       return newState;
     }
   }

--- a/ui/src/helper/cli.ts
+++ b/ui/src/helper/cli.ts
@@ -61,6 +61,17 @@ export const createNetwork = async () => {
   }
 };
 
+export async function runContainers() {
+  await createNetwork();
+  await deployDb();
+  await deployMq();
+  await deployTransform();
+  await deploySolr();
+
+  await waitTillReadyDb();
+  await deployRepository();
+}
+
 // Stop running containers in 'alfresco' network
 export const stopContainers = async () => {
   const containers = await alfrescoContainers();


### PR DESCRIPTION
Having commands to docker cli inside a reducer was a design problem. 
Error messages in development were related to React.Strictmode behaviour that was invoking dispatch twice: official reference https://reactjs.org/docs/strict-mode.html 