### PR TITLE
#6 Support for aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Development Recommendations:
 
 ## Enable Docker Extensions
 
-In Docker Desktop, go to `Preferences > Extensions` and check `Enable Docker Extensions`
+In Docker Desktop, go to `Preferences > Extensions` and check `Enable Docker Extensions` and `Show Docker Extensions system containers` options
 
 ## Running the extension
 
@@ -37,13 +37,9 @@ From the Docker Dashboard you can now navigate to the Extensions section.
 
 It should now list **Alfresco** as one of the available extensions.
 
-Click on **Run** button to run **Alfresco** in Docker and use <http://localhost:8080/alfresco> URL in your browser once the deployment is ready.
+Click on **Run** button to run **Alfresco** in Docker and once the deployment is ready click on **Open** button to start ACS in your browser.
 
 If you want to un-deploy Alfresco, click **Stop** button.
-
-## Known Issues
-
-- The extension doesn't work in Apple Silicon computers, since the Alfresco Docker Images are not available for that architecture
 
 ## Quick notes to get started with Development
 

--- a/ui/src/alfresco/DockerContainerCreate.tsx
+++ b/ui/src/alfresco/DockerContainerCreate.tsx
@@ -5,8 +5,7 @@ import {
   Button,
   CircularProgress,
   colors,
-  Stack,
-  Typography,
+  Stack
 } from '@mui/material';
 
 import PlayIcon from '@mui/icons-material/PlayArrow';
@@ -23,7 +22,6 @@ import {
 } from './services';
 import {
   canRun,
-  isRunning,
   canStop,
   isLoading,
   isStopping,
@@ -34,7 +32,7 @@ import {
 import { setup, runContainers, stopContainers } from '../helper/cli';
 import {
   ALFRESCO_7_3_CONFIGURATION,
-  ALFRESCO_7_2_CONFIGURATION,
+  ALFRESCO_7_3_CONFIGURATION_AARCH64,
 } from './configuration';
 import { CloudDownloadSharp } from '@mui/icons-material';
 
@@ -144,9 +142,9 @@ const FeedbackPanel = ({ alfrescoState }) => {
   );
 };
 
-export const DockerContainerCreate = () => {
-  const [configuration, setConfiguration] = useState(
-    ALFRESCO_7_3_CONFIGURATION
+export const DockerContainerCreate = ({dockerInfo}) => {
+  const [configuration] = useState(
+    dockerInfo.arch === 'x86_64' ? ALFRESCO_7_3_CONFIGURATION : ALFRESCO_7_3_CONFIGURATION_AARCH64
   );
   const [alfresco, dispatch] = useReducer<Reducer<ServiceStore, Action>>(
     serviceReducer,

--- a/ui/src/alfresco/DockerContainers.tsx
+++ b/ui/src/alfresco/DockerContainers.tsx
@@ -55,7 +55,7 @@ export const DockerContainers = () => {
             </Alert>
           </Box>
         ))}
-      { dockerInfo.arch != 'none' && <DockerContainerCreate dockerInfo={dockerInfo}/> }
+      { dockerInfo.arch !== 'none' && <DockerContainerCreate dockerInfo={dockerInfo}/> }
     </Stack>
   );
 };

--- a/ui/src/alfresco/DockerContainers.tsx
+++ b/ui/src/alfresco/DockerContainers.tsx
@@ -6,7 +6,6 @@ import { resources } from '../helper/resources';
 import { RAM_LIMIT } from './configuration';
 
 const enoughRAM = (dockerInfo: DockerInfo) => dockerInfo.RAM >= RAM_LIMIT;
-const rightArch = (dockerInfo: DockerInfo) => dockerInfo.arch === 'x86_64';
 
 const preconditions = [
   {
@@ -18,27 +17,20 @@ const preconditions = [
         {resources.HOME.RAM_AVAILABLE_MESSAGE + info.RAM.toFixed(2)}
       </div>
     ),
-  },
-  {
-    cond: rightArch,
-    title: 'Docker Desktop Architecture not supported!',
-    message: (info) =>
-      'Architecture ' + info.arch + ' is not supported by this extension!',
-  },
+  }
 ];
-type DockerInfo = {
+export type DockerInfo = {
   RAM: number;
-  arch: 'x86_64' | 'ARM_64';
+  arch: 'none' | 'x86_64' | 'aarch64';
 };
 export const DockerContainers = () => {
   const [dockerInfo, setDockerInfo] = useState<DockerInfo>({
     RAM: RAM_LIMIT,
-    arch: 'x86_64',
+    arch: 'none',
   });
 
   async function readDockerInfo() {
     let info = await getDockerInfo();
-
     setDockerInfo({
       RAM: info?.MemTotal / 1024 / 1024 / 1024,
       arch: info?.Architecture,
@@ -63,7 +55,7 @@ export const DockerContainers = () => {
             </Alert>
           </Box>
         ))}
-      {dockerInfo.arch === 'x86_64' && <DockerContainerCreate />}
+      { dockerInfo.arch != 'none' && <DockerContainerCreate dockerInfo={dockerInfo}/> }
     </Stack>
   );
 };

--- a/ui/src/alfresco/configuration.ts
+++ b/ui/src/alfresco/configuration.ts
@@ -1,4 +1,4 @@
-import { ServiceConfiguration, ServiceName } from './types';
+import { ServiceConfiguration } from './types';
 
 export const RAM_LIMIT = 10;
 
@@ -172,3 +172,22 @@ export const ALFRESCO_7_3_CONFIGURATION: ServiceConfiguration[] =
     },
     { name: 'postgres', image: 'postgres:14.4' },
   ]);
+export const ALFRESCO_7_3_CONFIGURATION_AARCH64: ServiceConfiguration[] =
+  createConfigurationFor([
+    {
+      name: 'alfresco',
+      image: 'angelborroy/alfresco-content-repository-community:7.3.0',
+    },
+    {
+      name: 'activemq',
+      image: 'alfresco/alfresco-activemq:5.17.1-jre11-rockylinux8',
+    },
+    { name: 'proxy', image: 'angelborroy/alfresco-acs-nginx:3.4.2' },
+    { name: 'content-app', image: 'angelborroy/alfresco-content-app:3.1.0' },
+    { name: 'solr6', image: 'angelborroy/alfresco-search-services:2.0.5.1' },
+    {
+      name: 'transform-core-aio',
+      image: 'angelborroy/alfresco-transform-core-aio:3.0.0',
+    },
+    { name: 'postgres', image: 'postgres:14.4' },
+  ]);  

--- a/ui/src/helper/cli.ts
+++ b/ui/src/helper/cli.ts
@@ -97,7 +97,7 @@ export const removeContainer = async (containerName: string) => {
     'network=alfresco',
   ]);
   if (result.stdout.length > 0) {
-    await ddClient.docker.cli.exec('container', ['rm', '-v', containerName]);
+    await ddClient.docker.cli.exec('container', ['rm', '-f', '-v', containerName]);
   }
 };
 export async function deployService(config: ServiceConfiguration) {
@@ -112,8 +112,10 @@ export async function deployService(config: ServiceConfiguration) {
   ]);
   if (running.stdout.length === 0) {
     await removeContainer(config.service);
+    ddClient.docker.cli.exec('container', ['rm', '-f', '-v', config.service]);
     await ddClient.docker.cli.exec('run', [
       '-d',
+      '--rm',
       '--name',
       config.service,
       '--network',

--- a/ui/src/helper/resources.ts
+++ b/ui/src/helper/resources.ts
@@ -17,10 +17,10 @@ export const resources = {
     NAME: 'NAME',
     STATUS: 'STATUS',
     DETAILS: '',
-    START: 'START',
+    START: 'OPEN',
     ALFRESCO_READY_TITLE: 'Alfresco is Ready!',
     ALFRESCO_READY_MESSAGE:
-      'Click START button and use default credentials admin/admin',
+      'Click OPEN button and use default credentials admin/admin',
     ALFRESCO_STARTING_TITLE: 'Alfresco is starting',
     ALFRESCO_STARTING_MESSAGE:
       'Wait a few minutes till Alfresco is ready. You may use the Refresh button to update status.',


### PR DESCRIPTION
Using "angelborroy" Docker Images for aarch64 computers, since "alfresco" Docker Images still don't support this architecture.