### PR TITLE
Set `composefile` prop in `metadata.json`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,4 @@ COPY metadata.json .
 COPY alfresco.svg .
 COPY --from=client-builder /ui/build ui
 #CMD /service -socket /run/guest-services/extension-alfresco-extension.sock
+ENTRYPOINT ["/bin/sh","-c","sleep infinity"]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,8 @@
 {
   "icon": "alfresco.svg",
-
+  "vm": {
+    "composefile": "docker-compose.yaml"
+  },
   "ui": {
     "dashboard-tab": {
       "title": "Alfresco",


### PR DESCRIPTION
This PR sets the `composefile` prop in `metadata.json`. This is needed so that the containers started on-demand when the user clicks on the UI will be removed when the extension is uninstalled.

By default, the containers created with `ddClient.docker.cli.exec` will have the label `com.docker.compose.project": "angelborroy_alfresco-extension-desktop-extension"` added automatically by the Extensions framework. When the extension is uninstalled, the framework will `docker compose down` and will remove all the containers that were started on-demand using the SDK.

